### PR TITLE
 feature: settings and account management

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,6 +121,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3:1.3.2")
+    implementation("androidx.compose.material:material-icons-extended")
 
     // Tooling
     debugImplementation("androidx.compose.ui:ui-tooling")

--- a/app/src/main/java/com/shipthis/go/data/api/AuthApiService.kt
+++ b/app/src/main/java/com/shipthis/go/data/api/AuthApiService.kt
@@ -1,5 +1,6 @@
 package com.shipthis.go.data.api
 
+import com.shipthis.go.data.model.GDPRRequest
 import com.shipthis.go.data.model.Self
 import com.shipthis.go.data.model.SelfWithJWT
 import retrofit2.http.Body
@@ -18,6 +19,15 @@ interface AuthApiService {
 
     @POST("me/terms")
     suspend fun acceptTerms(@Body request: EmptyBody = EmptyBody()): Self
+
+    @GET("me/gdpr")
+    suspend fun getGdprStatus(): List<GDPRRequest>
+
+    @POST("me/gdpr/export")
+    suspend fun requestGdprExport(@Body request: EmptyBody = EmptyBody()): Unit
+
+    @POST("me/gdpr/delete")
+    suspend fun requestGdprDelete(@Body request: EmptyBody = EmptyBody()): Unit
 }
 
 // Request/Response models

--- a/app/src/main/java/com/shipthis/go/data/model/GDPRRequest.kt
+++ b/app/src/main/java/com/shipthis/go/data/model/GDPRRequest.kt
@@ -1,0 +1,26 @@
+package com.shipthis.go.data.model
+
+import com.google.gson.annotations.SerializedName
+
+enum class GDPRRequestType {
+    EXPORT,
+    DELETE
+}
+
+enum class GDPRRequestStatus {
+    PENDING,
+    COMPLETED,
+    FAILED
+}
+
+data class GDPRRequest(
+    val id: String,
+    val type: GDPRRequestType,
+    val status: GDPRRequestStatus,
+    val details: Any?,
+    @SerializedName("createdAt")
+    val createdAt: String, // ISO 8601 format
+    @SerializedName("updatedAt")
+    val updatedAt: String // ISO 8601 format
+)
+

--- a/app/src/main/java/com/shipthis/go/data/model/Self.kt
+++ b/app/src/main/java/com/shipthis/go/data/model/Self.kt
@@ -8,6 +8,10 @@ data class Self(
     val details: UserDetails,
     val email: String,
     val id: String,
+    @SerializedName("isBetaUser")
+    val isBetaUser: Boolean,
+    @SerializedName("accountType")
+    val accountType: TierTypes,
     @SerializedName("updatedAt")
     val updatedAt: String // ISO 8601 format
 )

--- a/app/src/main/java/com/shipthis/go/data/model/SelfWithJWT.kt
+++ b/app/src/main/java/com/shipthis/go/data/model/SelfWithJWT.kt
@@ -9,6 +9,10 @@ data class SelfWithJWT(
     val details: UserDetails,
     val email: String,
     val id: String,
+    @SerializedName("isBetaUser")
+    val isBetaUser: Boolean,
+    @SerializedName("accountType")
+    val accountType: TierTypes,
     @SerializedName("updatedAt")
     val updatedAt: String // ISO 8601 format
 )

--- a/app/src/main/java/com/shipthis/go/data/model/TierTypes.kt
+++ b/app/src/main/java/com/shipthis/go/data/model/TierTypes.kt
@@ -1,0 +1,8 @@
+package com.shipthis.go.data.model
+
+enum class TierTypes {
+    UNLIMITED,
+    ENTERPRISE,
+    FREE
+}
+

--- a/app/src/main/java/com/shipthis/go/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/shipthis/go/data/repository/AuthRepository.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.google.gson.Gson
 import com.shipthis.go.data.api.AuthApiService
+import com.shipthis.go.data.api.EmptyBody
+import com.shipthis.go.data.model.GDPRRequest
 import com.shipthis.go.data.model.Self
 import com.shipthis.go.data.model.SelfWithJWT
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -75,6 +77,8 @@ class AuthRepository @Inject constructor(
                 details = currentSelf.details,
                 email = currentSelf.email,
                 id = currentSelf.id,
+                isBetaUser = currentSelf.isBetaUser,
+                accountType = currentSelf.accountType,
                 updatedAt = currentSelf.updatedAt
             )
             saveUserInternal(updatedUser)
@@ -115,6 +119,19 @@ class AuthRepository @Inject constructor(
     // Call this when we get a 401 to clear invalid JWT
     fun handleUnauthorized() {
         clearSession()
+    }
+
+    // GDPR methods
+    suspend fun fetchGdprStatus(): List<GDPRRequest> {
+        return authApiService.getGdprStatus()
+    }
+
+    suspend fun requestExport() {
+        authApiService.requestGdprExport(EmptyBody())
+    }
+
+    suspend fun requestDelete() {
+        authApiService.requestGdprDelete(EmptyBody())
     }
 }
 

--- a/app/src/main/java/com/shipthis/go/ui/components/LoggedInScreenLayout.kt
+++ b/app/src/main/java/com/shipthis/go/ui/components/LoggedInScreenLayout.kt
@@ -1,0 +1,89 @@
+package com.shipthis.go.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoggedInScreenLayout(
+    navController: NavController,
+    currentRoute: String,
+    content: @Composable () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { }
+            )
+        },
+        bottomBar = {
+            NavigationBar {
+                NavigationBarItem(
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.Home,
+                            contentDescription = "Home"
+                        )
+                    },
+                    label = { Text("Home") },
+                    selected = currentRoute == "home",
+                    onClick = {
+                        navController.navigate("home") {
+                            // Pop up to the start destination of the graph to
+                            // avoid building up a large stack of destinations
+                            // on the back stack as users select items
+                            popUpTo(navController.graph.startDestinationId) {
+                                saveState = true
+                            }
+                            // Avoid multiple copies of the same destination when
+                            // reselecting the same item
+                            launchSingleTop = true
+                            // Restore state when reselecting a previously selected item
+                            restoreState = true
+                        }
+                    }
+                )
+                NavigationBarItem(
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = "Settings"
+                        )
+                    },
+                    label = { Text("Settings") },
+                    selected = currentRoute == "settings",
+                    onClick = {
+                        navController.navigate("settings") {
+                            // Pop up to the start destination of the graph to
+                            // avoid building up a large stack of destinations
+                            // on the back stack as users select items
+                            popUpTo(navController.graph.startDestinationId) {
+                                saveState = true
+                            }
+                            // Avoid multiple copies of the same destination when
+                            // reselecting the same item
+                            launchSingleTop = true
+                            // Restore state when reselecting a previously selected item
+                            restoreState = true
+                        }
+                    }
+                )
+            }
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            content()
+        }
+    }
+}
+

--- a/app/src/main/java/com/shipthis/go/ui/navigation/ShipThisGoNavigation.kt
+++ b/app/src/main/java/com/shipthis/go/ui/navigation/ShipThisGoNavigation.kt
@@ -12,6 +12,7 @@ import com.shipthis.go.data.repository.AuthRepository
 import com.shipthis.go.ui.screens.home.HomeScreen
 import com.shipthis.go.ui.screens.login.LoginScreen
 import com.shipthis.go.ui.screens.login.OtpVerificationScreen
+import com.shipthis.go.ui.screens.settings.SettingsScreen
 
 @Composable
 fun ShipThisGoNavigation(
@@ -55,7 +56,11 @@ fun ShipThisGoNavigation(
         }
 
         composable("home") {
-            HomeScreen()
+            HomeScreen(navController = navController)
+        }
+
+        composable("settings") {
+            SettingsScreen(navController = navController)
         }
     }
 

--- a/app/src/main/java/com/shipthis/go/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/home/HomeScreen.kt
@@ -10,97 +10,106 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.compose.currentBackStackEntryAsState
 
 import android.app.Activity
 import com.google.zxing.integration.android.IntentIntegrator
 
+import com.shipthis.go.ui.components.LoggedInScreenLayout
 import com.shipthis.go.ui.components.rememberQrScannerLauncher
 
 @Composable
 fun HomeScreen(
+    navController: androidx.navigation.NavController,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-    val context = LocalContext.current
-    val activity = context as Activity
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route ?: "home"
 
-    val startQrScan = rememberQrScannerLauncher(activity) { result ->
-        if (!result.isNullOrBlank()) {
-            viewModel.updateBuildId(result)
-            viewModel.submitBuildId(context)
-        }
-    }
-
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+    LoggedInScreenLayout(
+        navController = navController,
+        currentRoute = currentRoute
     ) {
-        Text(
-            text = "Welcome to ShipThis Go!",
-            style = MaterialTheme.typography.headlineMedium
-        )
+        val uiState by viewModel.uiState.collectAsState()
+        val context = LocalContext.current
+        val activity = context as Activity
 
-        // Build ID Input
-        OutlinedTextField(
-            value = uiState.buildId,
-            onValueChange = { newValue ->
-                if (newValue.length <= 8) {
-                    viewModel.updateBuildId(newValue)
-                }
-            },
-            label = { Text("Build ID") },
-            placeholder = { Text("Enter Build ID (8 chars)") },
+        val startQrScan = rememberQrScannerLauncher(activity) { result ->
+            if (!result.isNullOrBlank()) {
+                viewModel.updateBuildId(result)
+                viewModel.submitBuildId(context)
+            }
+        }
+
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp),
-            enabled = !uiState.isLoading,
-            singleLine = true
-        )
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
-            Button(
-                onClick = startQrScan,
-                modifier = Modifier.weight(1f),
-                enabled = !uiState.isLoading
+            Text(
+                text = "Welcome to ShipThis Go!",
+                style = MaterialTheme.typography.headlineMedium
+            )
+
+            // Build ID Input
+            OutlinedTextField(
+                value = uiState.buildId,
+                onValueChange = { newValue ->
+                    if (newValue.length <= 8) {
+                        viewModel.updateBuildId(newValue)
+                    }
+                },
+                label = { Text("Build ID") },
+                placeholder = { Text("Enter Build ID (8 chars)") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                enabled = !uiState.isLoading,
+                singleLine = true
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Text("Scan QR")
+                Button(
+                    onClick = startQrScan,
+                    modifier = Modifier.weight(1f),
+                    enabled = !uiState.isLoading
+                ) {
+                    Text("Scan QR")
+                }
+
+                Button(
+                    onClick = { viewModel.submitBuildId(context) },
+                    modifier = Modifier.weight(1f),
+                    enabled = !uiState.isLoading
+                ) {
+                    Text("Submit")
+                }
             }
 
-            Button(
-                onClick = { viewModel.submitBuildId(context) },
-                modifier = Modifier.weight(1f),
-                enabled = !uiState.isLoading
-            ) {
-                Text("Submit")
+            // Status or Error
+            when {
+                uiState.isLoading -> {
+                    CircularProgressIndicator(modifier = Modifier.padding(16.dp))
+                }
+                uiState.error != null -> {
+                    Text(
+                        text = "Error: ${uiState.error}",
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(16.dp)
+                    )
+                }
+                else -> {
+                    Text(
+                        text = uiState.data ?: "No data yet",
+                        modifier = Modifier.padding(16.dp)
+                    )
+                }
             }
         }
-
-        // Status or Error
-        when {
-            uiState.isLoading -> {
-                CircularProgressIndicator(modifier = Modifier.padding(16.dp))
-            }
-            uiState.error != null -> {
-                Text(
-                    text = "Error: ${uiState.error}",
-                    color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.padding(16.dp)
-                )
-            }
-            else -> {
-                Text(
-                    text = uiState.data ?: "No data yet",
-                    modifier = Modifier.padding(16.dp)
-                )
-            }
-        }
-
-       
     }
 }

--- a/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsScreen.kt
@@ -1,0 +1,52 @@
+package com.shipthis.go.ui.screens.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+import com.shipthis.go.ui.components.LoggedInScreenLayout
+
+@Composable
+fun SettingsScreen(
+    navController: NavController,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route ?: "settings"
+
+    LoggedInScreenLayout(
+        navController = navController,
+        currentRoute = currentRoute
+    ) {
+        val uiState by viewModel.uiState.collectAsState()
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Settings",
+                style = MaterialTheme.typography.headlineMedium
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Settings content will go here",
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsScreen.kt
@@ -17,9 +17,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import com.shipthis.go.data.model.GDPRRequest
 import com.shipthis.go.data.model.GDPRRequestType
 import com.shipthis.go.ui.components.LoggedInScreenLayout
-import java.time.Instant
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
+import com.shipthis.go.util.DateUtil
 
 @Composable
 fun SettingsScreen(
@@ -253,21 +251,11 @@ fun PendingRequestCard(request: GDPRRequest) {
             Spacer(modifier = Modifier.height(4.dp))
 
             Text(
-                text = "Created: ${formatDate(request.createdAt)}",
+                text = "Created: ${DateUtil.formatDate(request.createdAt)}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-    }
-}
-
-fun formatDate(iso8601String: String): String {
-    return try {
-        val instant = Instant.parse(iso8601String)
-        val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
-        formatter.format(instant.atZone(java.time.ZoneId.systemDefault()))
-    } catch (e: Exception) {
-        iso8601String // Fallback to original string if parsing fails
     }
 }
 

--- a/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsScreen.kt
@@ -148,21 +148,33 @@ fun YourDataSection(viewModel: SettingsViewModel) {
         Spacer(modifier = Modifier.height(24.dp))
 
         // Pending requests list
-        if (pendingRequests.isNotEmpty()) {
-            Text(
-                text = "Pending Requests",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
+        if (pendingRequests.isNotEmpty() || isLoading) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Pending Requests",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.heightIn(max = 200.dp)
-            ) {
-                items(pendingRequests) { request ->
-                    PendingRequestCard(request = request)
+            if (pendingRequests.isNotEmpty()) {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.heightIn(max = 200.dp)
+                ) {
+                    items(pendingRequests) { request ->
+                        PendingRequestCard(request = request)
+                    }
                 }
             }
 
@@ -189,14 +201,7 @@ fun YourDataSection(viewModel: SettingsViewModel) {
                 enabled = !hasPendingExport && !isLoading,
                 modifier = Modifier.weight(1f)
             ) {
-                if (isLoading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(16.dp),
-                        color = MaterialTheme.colorScheme.onPrimary
-                    )
-                } else {
-                    Text("Export Data")
-                }
+                Text("Export Data")
             }
 
             Button(

--- a/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsScreen.kt
@@ -1,18 +1,25 @@
 package com.shipthis.go.ui.screens.settings
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
-
+import com.shipthis.go.data.model.GDPRRequest
+import com.shipthis.go.data.model.GDPRRequestType
 import com.shipthis.go.ui.components.LoggedInScreenLayout
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 @Composable
 fun SettingsScreen(
@@ -26,14 +33,12 @@ fun SettingsScreen(
         navController = navController,
         currentRoute = currentRoute
     ) {
-        val uiState by viewModel.uiState.collectAsState()
-
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.Top
         ) {
             Text(
                 text = "Settings",
@@ -42,11 +47,222 @@ fun SettingsScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
+            val user by viewModel.currentUser.collectAsState()
+            
+            user?.let { currentUser ->
+                Text(
+                    text = "Email: ${currentUser.email}",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                
+                Spacer(modifier = Modifier.height(16.dp))
+                
+                Text(
+                    text = "Account Type: ${currentUser.accountType.name}",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                
+                if (currentUser.isBetaUser) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    
+                    Text(
+                        text = "You have a beta account",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            } ?: run {
+                Text(
+                    text = "No user information available",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Your Data section
+            YourDataSection(viewModel = viewModel)
+        }
+    }
+}
+
+@Composable
+fun YourDataSection(viewModel: SettingsViewModel) {
+    val pendingRequests by viewModel.pendingRequests.collectAsState()
+    val hasPendingExport by viewModel.hasPendingExport.collectAsState()
+    val hasPendingDelete by viewModel.hasPendingDelete.collectAsState()
+    val showDeleteConfirmation by viewModel.showDeleteConfirmation.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
+
+    // Delete confirmation dialog
+    if (showDeleteConfirmation) {
+        AlertDialog(
+            onDismissRequest = { viewModel.hideDeleteConfirmation() },
+            title = {
+                Text(text = "Delete Account")
+            },
+            text = {
+                Text(
+                    text = "Are you sure you want to delete your account?\n" +
+                            "This will permanently delete your account and all associated data. " +
+                            "This action cannot be undone.\n\n" +
+                            "We process deletion requests manually - which may take up to 30 days.\n\n" +
+                            "If you're sure, click Delete to proceed. Otherwise, click Cancel to keep your account."
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { viewModel.requestAccountDeletion() }
+                ) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { viewModel.hideDeleteConfirmation() }
+                ) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    Column {
+        Text(
+            text = "Your Data",
+            style = MaterialTheme.typography.headlineSmall
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "We take your privacy seriously. You can request a copy of your data or " +
+                    "delete your account at any time.\n\n" +
+                    "All requests are processed manually to ensure security and compliance " +
+                    "with our Privacy Policy. This may take up to 30 days, but we'll do our best " +
+                    "to handle it as quickly as possible.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Pending requests list
+        if (pendingRequests.isNotEmpty()) {
             Text(
-                text = "Settings content will go here",
-                style = MaterialTheme.typography.bodyMedium
+                text = "Pending Requests",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.heightIn(max = 200.dp)
+            ) {
+                items(pendingRequests) { request ->
+                    PendingRequestCard(request = request)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        // Error message
+        error?.let {
+            Text(
+                text = "Error: $it",
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(bottom = 8.dp)
             )
         }
+
+        // Action buttons
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Button(
+                onClick = { viewModel.requestDataExport() },
+                enabled = !hasPendingExport && !isLoading,
+                modifier = Modifier.weight(1f)
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                } else {
+                    Text("Export Data")
+                }
+            }
+
+            Button(
+                onClick = { viewModel.showDeleteConfirmation() },
+                enabled = !hasPendingDelete && !isLoading,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error
+                ),
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Delete Account")
+            }
+        }
+    }
+}
+
+@Composable
+fun PendingRequestCard(request: GDPRRequest) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = when (request.type) {
+                        GDPRRequestType.EXPORT -> "Data Export"
+                        GDPRRequestType.DELETE -> "Account Deletion"
+                    },
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = "PENDING",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = "Created: ${formatDate(request.createdAt)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+fun formatDate(iso8601String: String): String {
+    return try {
+        val instant = Instant.parse(iso8601String)
+        val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+        formatter.format(instant.atZone(java.time.ZoneId.systemDefault()))
+    } catch (e: Exception) {
+        iso8601String // Fallback to original string if parsing fails
     }
 }
 

--- a/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsViewModel.kt
@@ -35,7 +35,7 @@ class SettingsViewModel @Inject constructor(
     private val _showDeleteConfirmation = MutableStateFlow(false)
     val showDeleteConfirmation: StateFlow<Boolean> = _showDeleteConfirmation.asStateFlow()
 
-    val pendingRequests: StateFlow<List<GDPRRequest>> = _gdprRequests.asStateFlow()
+    val pendingRequests: StateFlow<List<GDPRRequest>> = _gdprRequests
         .map { requests ->
             requests.filter { it.status == GDPRRequestStatus.PENDING }
         }

--- a/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import com.shipthis.go.data.model.GDPRRequest
 import com.shipthis.go.data.model.GDPRRequestStatus
 import com.shipthis.go.data.model.GDPRRequestType
 import com.shipthis.go.data.repository.AuthRepository
+import com.shipthis.go.util.ErrorHandler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -18,7 +19,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val errorHandler: ErrorHandler
 ) : ViewModel() {
 
     val currentUser = authRepository.currentUser
@@ -76,7 +78,7 @@ class SettingsViewModel @Inject constructor(
                 _error.value = null
                 _gdprRequests.value = authRepository.fetchGdprStatus()
             } catch (e: Exception) {
-                _error.value = e.message ?: "Failed to load GDPR requests"
+                _error.value = errorHandler.getErrorMessage(e)
             } finally {
                 _isLoading.value = false
             }
@@ -92,7 +94,7 @@ class SettingsViewModel @Inject constructor(
                 // Refresh the list after successful request
                 loadGdprRequests()
             } catch (e: Exception) {
-                _error.value = e.message ?: "Failed to request data export"
+                _error.value = errorHandler.getErrorMessage(e)
             } finally {
                 _isLoading.value = false
             }
@@ -109,7 +111,7 @@ class SettingsViewModel @Inject constructor(
                 // Refresh the list after successful request
                 loadGdprRequests()
             } catch (e: Exception) {
-                _error.value = e.message ?: "Failed to request account deletion"
+                _error.value = errorHandler.getErrorMessage(e)
             } finally {
                 _isLoading.value = false
             }

--- a/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsViewModel.kt
@@ -2,22 +2,126 @@ package com.shipthis.go.ui.screens.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.shipthis.go.data.model.GDPRRequest
+import com.shipthis.go.data.model.GDPRRequestStatus
+import com.shipthis.go.data.model.GDPRRequestType
+import com.shipthis.go.data.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class SettingsViewModel @Inject constructor() : ViewModel() {
+class SettingsViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(SettingsUiState())
-    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+    val currentUser = authRepository.currentUser
 
-    // Future settings functionality can be added here
+    private val _gdprRequests = MutableStateFlow<List<GDPRRequest>>(emptyList())
+    val gdprRequests: StateFlow<List<GDPRRequest>> = _gdprRequests.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private val _showDeleteConfirmation = MutableStateFlow(false)
+    val showDeleteConfirmation: StateFlow<Boolean> = _showDeleteConfirmation.asStateFlow()
+
+    val pendingRequests: StateFlow<List<GDPRRequest>> = _gdprRequests.asStateFlow()
+        .map { requests ->
+            requests.filter { it.status == GDPRRequestStatus.PENDING }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+
+    val hasPendingExport: StateFlow<Boolean> = pendingRequests
+        .map { requests ->
+            requests.any { it.type == GDPRRequestType.EXPORT }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false
+        )
+
+    val hasPendingDelete: StateFlow<Boolean> = pendingRequests
+        .map { requests ->
+            requests.any { it.type == GDPRRequestType.DELETE }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false
+        )
+
+    init {
+        loadGdprRequests()
+    }
+
+    fun loadGdprRequests() {
+        viewModelScope.launch {
+            try {
+                _isLoading.value = true
+                _error.value = null
+                _gdprRequests.value = authRepository.fetchGdprStatus()
+            } catch (e: Exception) {
+                _error.value = e.message ?: "Failed to load GDPR requests"
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    fun requestDataExport() {
+        viewModelScope.launch {
+            try {
+                _isLoading.value = true
+                _error.value = null
+                authRepository.requestExport()
+                // Refresh the list after successful request
+                loadGdprRequests()
+            } catch (e: Exception) {
+                _error.value = e.message ?: "Failed to request data export"
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    fun requestAccountDeletion() {
+        viewModelScope.launch {
+            try {
+                _isLoading.value = true
+                _error.value = null
+                authRepository.requestDelete()
+                _showDeleteConfirmation.value = false
+                // Refresh the list after successful request
+                loadGdprRequests()
+            } catch (e: Exception) {
+                _error.value = e.message ?: "Failed to request account deletion"
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    fun showDeleteConfirmation() {
+        _showDeleteConfirmation.value = true
+    }
+
+    fun hideDeleteConfirmation() {
+        _showDeleteConfirmation.value = false
+    }
 }
-
-data class SettingsUiState(
-    val placeholder: String = "" // Future settings state can be added here
-)
 

--- a/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/settings/SettingsViewModel.kt
@@ -1,0 +1,23 @@
+package com.shipthis.go.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor() : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SettingsUiState())
+    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    // Future settings functionality can be added here
+}
+
+data class SettingsUiState(
+    val placeholder: String = "" // Future settings state can be added here
+)
+

--- a/app/src/main/java/com/shipthis/go/util/DateUtil.kt
+++ b/app/src/main/java/com/shipthis/go/util/DateUtil.kt
@@ -1,0 +1,29 @@
+package com.shipthis.go.util
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+/**
+ * Utility object for date formatting operations.
+ */
+object DateUtil {
+    /**
+     * Formats an ISO 8601 date string to a localized medium date format.
+     * Falls back to the original string if parsing fails.
+     *
+     * @param iso8601String The ISO 8601 formatted date string
+     * @return A formatted date string in medium format, or the original string if parsing fails
+     */
+    fun formatDate(iso8601String: String): String {
+        return try {
+            val instant = Instant.parse(iso8601String)
+            val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+            formatter.format(instant.atZone(ZoneId.systemDefault()))
+        } catch (e: Exception) {
+            iso8601String // Fallback to original string if parsing fails
+        }
+    }
+}
+


### PR DESCRIPTION
## Overview

This is to resolve #26 - adding a "Settings" screen with GDPR export and delete buttons.

## What's changed

- Updated the Selt data type
- Added GDPRRequest data type
- New layout with a bottom navigation bar used when logged in
- Added settings screen
  - Showing email, account type and if user is a beta user
  - Data section on the settings screen
    - Shows same copy as website
    - List of pending requests
    - Buttons to make new requests (if no pending)
    - Modal confirmation shown when pressing delete

## Screenshots
| Settings | Modal |
|----------|-------|
| <img width="433" height="962" alt="0" src="https://github.com/user-attachments/assets/73e32f2c-fe21-4533-b4ac-2d09a629c453" /> | <img width="433" height="962" alt="0" src="https://github.com/user-attachments/assets/6d1ef527-7010-45d7-b46e-d38fb5b1773d" /> |




