### PR TITLE
feature: saving build details to local db after launch and adding screen to see all previous builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,6 +146,12 @@ dependencies {
     // Coroutines (align with Kotlin 2.1.0)
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
 
+    // Room Database
+    val roomVersion = "2.6.1"
+    implementation("androidx.room:room-runtime:$roomVersion")
+    implementation("androidx.room:room-ktx:$roomVersion")
+    ksp("androidx.room:room-compiler:$roomVersion")
+
     // Networking
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")

--- a/app/src/main/java/com/shipthis/go/data/local/Converters.kt
+++ b/app/src/main/java/com/shipthis/go/data/local/Converters.kt
@@ -1,0 +1,41 @@
+package com.shipthis.go.data.local
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.JsonElement
+
+/**
+ * Type converters for Room database
+ * Handles conversion of complex types that Room doesn't support natively
+ */
+class Converters {
+    
+    private val gson = Gson()
+    
+    /**
+     * Converts the details: Any? field to a JSON string for storage
+     */
+    @TypeConverter
+    fun fromDetails(details: Any?): String? {
+        if (details == null) return null
+        return try {
+            gson.toJson(details)
+        } catch (e: Exception) {
+            null
+        }
+    }
+    
+    /**
+     * Converts JSON string back to Any? for the details field
+     */
+    @TypeConverter
+    fun toDetails(json: String?): Any? {
+        if (json == null) return null
+        return try {
+            gson.fromJson(json, JsonElement::class.java)
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+

--- a/app/src/main/java/com/shipthis/go/data/local/GoBuildDao.kt
+++ b/app/src/main/java/com/shipthis/go/data/local/GoBuildDao.kt
@@ -1,0 +1,38 @@
+package com.shipthis.go.data.local
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.shipthis.go.data.model.GoBuild
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface GoBuildDao {
+    
+    /**
+     * Get all builds ordered by creation date (newest first)
+     */
+    @Query("SELECT * FROM go_builds ORDER BY createdAt DESC")
+    fun getAllGoBuilds(): Flow<List<GoBuild>>
+    
+    /**
+     * Get a build by ID
+     */
+    @Query("SELECT * FROM go_builds WHERE id = :id")
+    suspend fun getGoBuildById(id: String): GoBuild?
+    
+    /**
+     * Insert a build, ignoring if it already exists (based on primary key)
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertGoBuild(goBuild: GoBuild)
+    
+    /**
+     * Delete a build
+     */
+    @Delete
+    suspend fun deleteGoBuild(goBuild: GoBuild)
+}
+

--- a/app/src/main/java/com/shipthis/go/data/local/GoBuildDatabase.kt
+++ b/app/src/main/java/com/shipthis/go/data/local/GoBuildDatabase.kt
@@ -1,0 +1,17 @@
+package com.shipthis.go.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.shipthis.go.data.model.GoBuild
+
+@Database(
+    entities = [GoBuild::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(Converters::class)
+abstract class GoBuildDatabase : RoomDatabase() {
+    abstract fun goBuildDao(): GoBuildDao
+}
+

--- a/app/src/main/java/com/shipthis/go/data/model/GoBuild.kt
+++ b/app/src/main/java/com/shipthis/go/data/model/GoBuild.kt
@@ -1,12 +1,20 @@
 package com.shipthis.go.data.model
 
+import androidx.room.Embedded
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.TypeConverters
 import com.google.gson.annotations.SerializedName
+import com.shipthis.go.data.local.Converters
 
 /**
  * Data class representing a GoBuild from the ShipThis API
  * Based on the PublicGoBuild type from the server
  */
+@Entity(tableName = "go_builds")
+@TypeConverters(Converters::class)
 data class GoBuild(
+    @PrimaryKey
     val id: String,
     @SerializedName("jobId")
     val jobId: String,
@@ -23,8 +31,10 @@ data class GoBuild(
     val createdAt: String,
     @SerializedName("updatedAt")
     val updatedAt: String,
+    @Embedded(prefix = "jobDetails_")
     @SerializedName("jobDetails")
     val jobDetails: JobDetails,
+    @Embedded(prefix = "project_")
     val project: Project
 )
 
@@ -61,6 +71,7 @@ data class Project(
     val createdAt: String,
     @SerializedName("updatedAt")
     val updatedAt: String,
+    @Embedded(prefix = "details_")
     val details: ProjectDetails
 )
 

--- a/app/src/main/java/com/shipthis/go/data/model/GoBuild.kt
+++ b/app/src/main/java/com/shipthis/go/data/model/GoBuild.kt
@@ -71,7 +71,7 @@ data class Project(
     val createdAt: String,
     @SerializedName("updatedAt")
     val updatedAt: String,
-    @Embedded(prefix = "details_")
+    @Embedded(prefix = "project_details_")
     val details: ProjectDetails
 )
 

--- a/app/src/main/java/com/shipthis/go/data/repository/GoBuildRepository.kt
+++ b/app/src/main/java/com/shipthis/go/data/repository/GoBuildRepository.kt
@@ -1,15 +1,43 @@
 package com.shipthis.go.data.repository
 
 import com.shipthis.go.data.api.GoBuildApiService
+import com.shipthis.go.data.local.GoBuildDao
 import com.shipthis.go.data.model.GoBuild
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class GoBuildRepository @Inject constructor(
-    private val apiService: GoBuildApiService
+    private val apiService: GoBuildApiService,
+    private val goBuildDao: GoBuildDao
 ) {
+    /**
+     * Fetch a GoBuild from the API
+     */
     suspend fun getGoBuild(buildId: String): GoBuild {
         return apiService.getGoBuild(buildId)
+    }
+    
+    /**
+     * Save a GoBuild to the local database
+     * Duplicates are ignored (based on primary key)
+     */
+    suspend fun saveGoBuild(goBuild: GoBuild) {
+        goBuildDao.insertGoBuild(goBuild)
+    }
+    
+    /**
+     * Get all GoBuilds from the local database (newest first)
+     */
+    fun getAllGoBuilds(): Flow<List<GoBuild>> {
+        return goBuildDao.getAllGoBuilds()
+    }
+    
+    /**
+     * Get a GoBuild by ID from the local database
+     */
+    suspend fun getGoBuildById(id: String): GoBuild? {
+        return goBuildDao.getGoBuildById(id)
     }
 }

--- a/app/src/main/java/com/shipthis/go/di/DatabaseModule.kt
+++ b/app/src/main/java/com/shipthis/go/di/DatabaseModule.kt
@@ -1,0 +1,36 @@
+package com.shipthis.go.di
+
+import android.content.Context
+import androidx.room.Room
+import com.shipthis.go.data.local.GoBuildDao
+import com.shipthis.go.data.local.GoBuildDatabase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+    
+    @Provides
+    @Singleton
+    fun provideGoBuildDatabase(
+        @ApplicationContext context: Context
+    ): GoBuildDatabase {
+        return Room.databaseBuilder(
+            context,
+            GoBuildDatabase::class.java,
+            "go_build_database"
+        ).build()
+    }
+    
+    @Provides
+    @Singleton
+    fun provideGoBuildDao(database: GoBuildDatabase): GoBuildDao {
+        return database.goBuildDao()
+    }
+}
+

--- a/app/src/main/java/com/shipthis/go/ui/components/LoggedInScreenLayout.kt
+++ b/app/src/main/java/com/shipthis/go/ui/components/LoggedInScreenLayout.kt
@@ -3,6 +3,7 @@ package com.shipthis.go.ui.components
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -17,11 +18,6 @@ fun LoggedInScreenLayout(
     content: @Composable () -> Unit
 ) {
     Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { }
-            )
-        },
         bottomBar = {
             NavigationBar {
                 NavigationBarItem(
@@ -35,6 +31,31 @@ fun LoggedInScreenLayout(
                     selected = currentRoute == "home",
                     onClick = {
                         navController.navigate("home") {
+                            // Pop up to the start destination of the graph to
+                            // avoid building up a large stack of destinations
+                            // on the back stack as users select items
+                            popUpTo(navController.graph.startDestinationId) {
+                                saveState = true
+                            }
+                            // Avoid multiple copies of the same destination when
+                            // reselecting the same item
+                            launchSingleTop = true
+                            // Restore state when reselecting a previously selected item
+                            restoreState = true
+                        }
+                    }
+                )
+                NavigationBarItem(
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.List,
+                            contentDescription = "Builds"
+                        )
+                    },
+                    label = { Text("Builds") },
+                    selected = currentRoute == "builds",
+                    onClick = {
+                        navController.navigate("builds") {
                             // Pop up to the start destination of the graph to
                             // avoid building up a large stack of destinations
                             // on the back stack as users select items

--- a/app/src/main/java/com/shipthis/go/ui/navigation/ShipThisGoNavigation.kt
+++ b/app/src/main/java/com/shipthis/go/ui/navigation/ShipThisGoNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.shipthis.go.data.repository.AuthRepository
+import com.shipthis.go.ui.screens.builds.BuildsScreen
 import com.shipthis.go.ui.screens.home.HomeScreen
 import com.shipthis.go.ui.screens.login.LoginScreen
 import com.shipthis.go.ui.screens.login.OtpVerificationScreen
@@ -57,6 +58,10 @@ fun ShipThisGoNavigation(
 
         composable("home") {
             HomeScreen(navController = navController)
+        }
+
+        composable("builds") {
+            BuildsScreen(navController = navController)
         }
 
         composable("settings") {

--- a/app/src/main/java/com/shipthis/go/ui/screens/builds/BuildsScreen.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/builds/BuildsScreen.kt
@@ -1,0 +1,101 @@
+package com.shipthis.go.ui.screens.builds
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.shipthis.go.ui.components.LoggedInScreenLayout
+
+@Composable
+fun BuildsScreen(
+    navController: NavController,
+    viewModel: BuildsViewModel = hiltViewModel()
+) {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route ?: "builds"
+
+    LoggedInScreenLayout(
+        navController = navController,
+        currentRoute = currentRoute
+    ) {
+        val builds by viewModel.builds.collectAsState()
+        val isLoading by viewModel.isLoading.collectAsState()
+        val error by viewModel.error.collectAsState()
+        val context = LocalContext.current
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.Top
+        ) {
+            Text(
+                text = "Builds",
+                style = MaterialTheme.typography.headlineMedium
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            when {
+                isLoading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                error != null -> {
+                    Text(
+                        text = "Error: $error",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                builds.isEmpty() -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "No builds available",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        items(builds) { build ->
+                            GoBuildCard(
+                                goBuild = build,
+                                onLaunchClick = { goBuild ->
+                                    viewModel.launchBuild(context, goBuild)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/shipthis/go/ui/screens/builds/BuildsViewModel.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/builds/BuildsViewModel.kt
@@ -1,25 +1,12 @@
 package com.shipthis.go.ui.screens.builds
 
 import android.content.Context
-import android.content.Intent
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.android.play.core.splitinstall.SplitInstallManagerFactory
-import com.google.android.play.core.splitinstall.SplitInstallRequest
-import com.google.android.play.core.splitinstall.SplitInstallSessionState
-import com.google.android.play.core.splitinstall.SplitInstallStateUpdatedListener
-import com.google.android.play.core.splitinstall.model.SplitInstallSessionStatus
 import com.shipthis.go.data.model.GoBuild
 import com.shipthis.go.data.repository.GoBuildRepository
-import com.shipthis.go.util.CrashMarker
-import com.shipthis.go.util.SocketLogHandler
+import com.shipthis.go.util.BuildLauncher
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.io.*
-import java.net.HttpURLConnection
-import java.net.URL
-import java.util.zip.ZipEntry
-import java.util.zip.ZipInputStream
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,7 +19,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class BuildsViewModel @Inject constructor(
     private val repository: GoBuildRepository,
-    private val socketLogHandler: SocketLogHandler
+    private val buildLauncher: BuildLauncher
 ) : ViewModel() {
 
     private val _isLoading = MutableStateFlow(false)
@@ -55,27 +42,8 @@ class BuildsViewModel @Inject constructor(
                 _isLoading.value = true
                 _error.value = null
 
-                val assetsDir = File(context.filesDir, "assets")
-                val zipFile = File(context.cacheDir, "game.zip")
-
-                // Clean old files
-                deleteRecursively(assetsDir)
-                assetsDir.mkdirs()
-
-                // Download game
-                downloadFile(goBuild.url, zipFile) { }
-
-                // Unzip game
-                unzip(zipFile, assetsDir) { }
-
-                // Set buildId in log handler for runtime logging
-                socketLogHandler.setBuildId(goBuild.id)
-
-                // Mark the start of this runtime session
-                CrashMarker.markStart(context, goBuild.id)
-
-                val gameEngineVersion = goBuild.jobDetails.gameEngineVersion
-                launchGame(context, gameEngineVersion)
+                // Launch the build using BuildLauncher service
+                buildLauncher.launchBuild(context, goBuild)
 
                 _isLoading.value = false
                 _error.value = null
@@ -85,160 +53,5 @@ class BuildsViewModel @Inject constructor(
             }
         }
     }
-
-    private fun launchGame(context: Context, version: String) {
-        val manager = SplitInstallManagerFactory.create(context)
-        val moduleName =
-            when (version) {
-                "4.5" -> "godot_v4_5"
-                "4.4" -> "godot_v4_4"
-                "4.3" -> "godot_v4_3"
-                "4.2" -> "godot_v4_2"
-                "4.1" -> "godot_v4_1"
-                "4.0" -> "godot_v4_0"
-                "3.6", "3.7" -> "godot_v3_x"
-                else -> "godot_v4_5"
-            }
-
-        if (manager.installedModules.contains(moduleName)) {
-            startGodotActivity(context, version)
-            return
-        }
-
-        val request = SplitInstallRequest.newBuilder().addModule(moduleName).build()
-
-        val listener = object : SplitInstallStateUpdatedListener {
-            override fun onStateUpdate(state: SplitInstallSessionState) {
-                if (state.moduleNames().contains(moduleName)) {
-                    when (state.status()) {
-                        SplitInstallSessionStatus.DOWNLOADING -> {
-                            Log.i(
-                                "ShipThis",
-                                "Downloading $moduleName (${state.bytesDownloaded()}/${state.totalBytesToDownload()})"
-                            )
-                        }
-                        SplitInstallSessionStatus.INSTALLING -> {
-                            Log.i("ShipThis", "Installing $moduleName…")
-                        }
-                        SplitInstallSessionStatus.INSTALLED -> {
-                            Log.i("ShipThis", "$moduleName installed, launching")
-                            manager.unregisterListener(this)
-                            startGodotActivity(context, version)
-                        }
-                        SplitInstallSessionStatus.FAILED -> {
-                            Log.e("ShipThis", "Install failed: ${state.errorCode()}")
-                            manager.unregisterListener(this)
-                        }
-                    }
-                }
-            }
-        }
-
-        manager.registerListener(listener)
-        manager.startInstall(request)
-    }
-
-    private fun startGodotActivity(context: Context, version: String) {
-        val className =
-            when (version) {
-                "4.5" -> "com.shipthis.go.GodotAppv4_5"
-                "4.4" -> "com.shipthis.go.GodotAppv4_4"
-                "4.3" -> "com.shipthis.go.GodotAppv4_3"
-                "4.2" -> "com.shipthis.go.GodotAppv4_2"
-                "4.1" -> "com.shipthis.go.GodotAppv4_1"
-                "4.0" -> "com.shipthis.go.GodotAppv4_0"
-                "3.6", "3.7" -> "com.shipthis.go.GodotAppv3_x"
-                else -> "com.shipthis.go.GodotAppv4_5"
-            }
-
-        val intent = Intent()
-        intent.setClassName(context.packageName, className)
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
-    }
-
-    // ---- IO helpers ----
-
-    private fun downloadFile(urlString: String, out: File, onProgress: (Int) -> Unit) {
-        val conn = URL(urlString).openConnection() as HttpURLConnection
-        conn.connectTimeout = 15000
-        conn.readTimeout = 300000
-        conn.connect()
-        val code = conn.responseCode
-        if (code != HttpURLConnection.HTTP_OK)
-            throw IOException("HTTP $code: ${conn.responseMessage}")
-
-        val length = conn.contentLength
-        var total = 0L
-        var lastPct = -1
-        conn.inputStream.buffered().use { input ->
-            FileOutputStream(out).buffered().use { output ->
-                val buf = ByteArray(8192)
-                while (true) {
-                    val n = input.read(buf)
-                    if (n == -1) break
-                    output.write(buf, 0, n)
-                    total += n
-                    if (length > 0) {
-                        val pct = (total * 100 / length).toInt()
-                        if (pct != lastPct) {
-                            lastPct = pct
-                            onProgress(pct)
-                        }
-                    }
-                }
-            }
-        }
-        conn.disconnect()
-    }
-
-    private fun unzip(zipFile: File, targetDir: File, onProgress: (Int) -> Unit) {
-        val totalEntries = countZipEntries(zipFile).coerceAtLeast(1)
-        var done = 0
-        ZipInputStream(FileInputStream(zipFile)).use { zis ->
-            var entry: ZipEntry?
-            val buf = ByteArray(8192)
-            while (true) {
-                entry = zis.nextEntry ?: break
-                val outFile = File(targetDir, entry.name)
-
-                // Zip Slip guard – prevents writing outside targetDir
-                val canonicalPath = outFile.canonicalPath
-                val canonicalTarget = targetDir.canonicalPath + File.separator
-                if (!canonicalPath.startsWith(canonicalTarget)) {
-                    throw IOException("Blocked Zip Slip: ${entry.name}")
-                }
-
-                if (entry.isDirectory) {
-                    outFile.mkdirs()
-                } else {
-                    outFile.parentFile?.mkdirs()
-                    FileOutputStream(outFile).use { os ->
-                        while (true) {
-                            val n = zis.read(buf)
-                            if (n == -1) break
-                            os.write(buf, 0, n)
-                        }
-                    }
-                }
-                zis.closeEntry()
-                done++
-                onProgress((done * 100) / totalEntries)
-            }
-        }
-    }
-
-    private fun countZipEntries(zip: File): Int {
-        var count = 0
-        ZipInputStream(FileInputStream(zip)).use { zis -> while (zis.nextEntry != null) count++ }
-        return count
-    }
-
-    private fun deleteRecursively(f: File) {
-        if (!f.exists()) return
-        if (f.isDirectory) f.listFiles()?.forEach { deleteRecursively(it) }
-        f.delete()
-    }
-
 }
 

--- a/app/src/main/java/com/shipthis/go/ui/screens/builds/GoBuildCard.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/builds/GoBuildCard.kt
@@ -1,0 +1,99 @@
+package com.shipthis.go.ui.screens.builds
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.shipthis.go.data.model.GoBuild
+import com.shipthis.go.util.DateUtil
+
+@Composable
+fun GoBuildCard(
+    goBuild: GoBuild,
+    onLaunchClick: (GoBuild) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            // Top row: Project name (left) + Status badge (right)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = goBuild.project.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = if (goBuild.isFound == true) "Available" else "Not Found",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (goBuild.isFound == true) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    },
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            // Version line
+            Text(
+                text = "v${goBuild.jobDetails.semanticVersion} #${goBuild.jobDetails.buildNumber}",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Game engine line
+            Text(
+                text = "${goBuild.jobDetails.gameEngine} ${goBuild.jobDetails.gameEngineVersion}",
+                style = MaterialTheme.typography.bodyMedium
+            )
+
+            // Created date line
+            Text(
+                text = "Created: ${DateUtil.formatDate(goBuild.createdAt)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+
+            // Git info (conditional)
+            val gitBranch = goBuild.jobDetails.gitBranch
+            val gitCommitHash = goBuild.jobDetails.gitCommitHash
+            if (gitBranch != null && gitCommitHash != null) {
+                val shortHash = gitCommitHash.take(7)
+                Text(
+                    text = "Branch: $gitBranch • $shortHash",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Launch button at bottom
+            Button(
+                onClick = { onLaunchClick(goBuild) },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Launch Build")
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/shipthis/go/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/shipthis/go/ui/screens/home/HomeViewModel.kt
@@ -1,24 +1,11 @@
 package com.shipthis.go.ui.screens.home
 
 import android.content.Context
-import android.content.Intent
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.android.play.core.splitinstall.SplitInstallManagerFactory
-import com.google.android.play.core.splitinstall.SplitInstallRequest
-import com.google.android.play.core.splitinstall.SplitInstallSessionState
-import com.google.android.play.core.splitinstall.SplitInstallStateUpdatedListener
-import com.google.android.play.core.splitinstall.model.SplitInstallSessionStatus
 import com.shipthis.go.data.repository.GoBuildRepository
-import com.shipthis.go.util.CrashMarker
-import com.shipthis.go.util.SocketLogHandler
+import com.shipthis.go.util.BuildLauncher
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.io.*
-import java.net.HttpURLConnection
-import java.net.URL
-import java.util.zip.ZipEntry
-import java.util.zip.ZipInputStream
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,7 +16,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val repository: GoBuildRepository,
-    private val socketLogHandler: SocketLogHandler
+    private val buildLauncher: BuildLauncher
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -60,31 +47,10 @@ class HomeViewModel @Inject constructor(
                 // Save the build to the local database
                 repository.saveGoBuild(goBuild)
 
-                val assetsDir = File(context.filesDir, "assets")
-                val zipFile = File(context.cacheDir, "game.zip")
-
-                updateStatus("Cleaning old files…")
-                deleteRecursively(assetsDir)
-                assetsDir.mkdirs()
-
-                updateStatus("Downloading game…")
-
-                downloadFile(goBuild.url, zipFile) { p -> updateStatus("Downloading… $p%") }
-
-                updateStatus("Unzipping game…")
-                unzip(zipFile, assetsDir) { p -> updateStatus("Unzipping… $p%") }
-
-                updateStatus("Launching…")
-
-                // Set buildId in log handler for runtime logging
-                socketLogHandler.setBuildId(goBuild.id)
-
-                // Mark the start of this runtime session
-                CrashMarker.markStart(context, goBuild.id)
-
-                var gameEngineVersion = goBuild.jobDetails.gameEngineVersion
-
-                launchGame(context, gameEngineVersion)
+                // Launch the build using BuildLauncher service
+                buildLauncher.launchBuild(context, goBuild) { status ->
+                    updateStatus(status)
+                }
 
                 _uiState.value =
                         _uiState.value.copy(
@@ -103,162 +69,8 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun launchGame(context: Context, version: String) {
-        val manager = SplitInstallManagerFactory.create(context)
-        val moduleName =
-                when (version) {
-                    "4.5" -> "godot_v4_5"
-                    "4.4" -> "godot_v4_4"
-                    "4.3" -> "godot_v4_3"
-                    "4.2" -> "godot_v4_2"
-                    "4.1" -> "godot_v4_1"
-                    "4.0" -> "godot_v4_0"
-                    "3.6", "3.7" -> "godot_v3_x"
-                    else -> "godot_v4_5"
-                }
-
-        if (manager.installedModules.contains(moduleName)) {
-            startGodotActivity(context, version)
-            return
-        }
-
-        val request = SplitInstallRequest.newBuilder().addModule(moduleName).build()
-
-        val listener = object : SplitInstallStateUpdatedListener {
-            override fun onStateUpdate(state: SplitInstallSessionState) {
-                if (state.moduleNames().contains(moduleName)) {
-                    when (state.status()) {
-                        SplitInstallSessionStatus.DOWNLOADING -> {
-                            Log.i(
-                                    "ShipThis",
-                                    "Downloading $moduleName (${state.bytesDownloaded()}/${state.totalBytesToDownload()})"
-                            )
-                        }
-                        SplitInstallSessionStatus.INSTALLING -> {
-                            Log.i("ShipThis", "Installing $moduleName…")
-                        }
-                        SplitInstallSessionStatus.INSTALLED -> {
-                            Log.i("ShipThis", "$moduleName installed, launching")
-                            manager.unregisterListener(this)
-                            startGodotActivity(context, version)
-                        }
-                        SplitInstallSessionStatus.FAILED -> {
-                            Log.e("ShipThis", "Install failed: ${state.errorCode()}")
-                            manager.unregisterListener(this)
-                        }
-                    }
-                }
-            }
-        }
-
-        manager.registerListener(listener)
-        manager.startInstall(request)
-    }
-
-    private fun startGodotActivity(context: Context, version: String) {
-        val className =
-                when (version) {
-                    "4.5" -> "com.shipthis.go.GodotAppv4_5"
-                    "4.4" -> "com.shipthis.go.GodotAppv4_4"
-                    "4.3" -> "com.shipthis.go.GodotAppv4_3"
-                    "4.2" -> "com.shipthis.go.GodotAppv4_2"
-                    "4.1" -> "com.shipthis.go.GodotAppv4_1"
-                    "4.0" -> "com.shipthis.go.GodotAppv4_0"
-                    "3.6", "3.7" -> "com.shipthis.go.GodotAppv3_x"
-                    else -> "com.shipthis.go.GodotAppv4_5"
-                }
-
-        val intent = Intent()
-        intent.setClassName(context.packageName, className)
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
-    }
-
     private fun updateStatus(msg: String) {
         _uiState.value = _uiState.value.copy(data = msg)
-    }
-
-    // ---- IO helpers ----
-
-    private fun downloadFile(urlString: String, out: File, onProgress: (Int) -> Unit) {
-        val conn = URL(urlString).openConnection() as HttpURLConnection
-        conn.connectTimeout = 15000
-        conn.readTimeout = 300000
-        conn.connect()
-        val code = conn.responseCode
-        if (code != HttpURLConnection.HTTP_OK)
-                throw IOException("HTTP $code: ${conn.responseMessage}")
-
-        val length = conn.contentLength
-        var total = 0L
-        var lastPct = -1
-        conn.inputStream.buffered().use { input ->
-            FileOutputStream(out).buffered().use { output ->
-                val buf = ByteArray(8192)
-                while (true) {
-                    val n = input.read(buf)
-                    if (n == -1) break
-                    output.write(buf, 0, n)
-                    total += n
-                    if (length > 0) {
-                        val pct = (total * 100 / length).toInt()
-                        if (pct != lastPct) {
-                            lastPct = pct
-                            onProgress(pct)
-                        }
-                    }
-                }
-            }
-        }
-        conn.disconnect()
-    }
-
-    private fun unzip(zipFile: File, targetDir: File, onProgress: (Int) -> Unit) {
-        val totalEntries = countZipEntries(zipFile).coerceAtLeast(1)
-        var done = 0
-        ZipInputStream(FileInputStream(zipFile)).use { zis ->
-            var entry: ZipEntry?
-            val buf = ByteArray(8192)
-            while (true) {
-                entry = zis.nextEntry ?: break
-                val outFile = File(targetDir, entry.name)
-
-                // Zip Slip guard – prevents writing outside targetDir
-                val canonicalPath = outFile.canonicalPath
-                val canonicalTarget = targetDir.canonicalPath + File.separator
-                if (!canonicalPath.startsWith(canonicalTarget)) {
-                    throw IOException("Blocked Zip Slip: ${entry.name}")
-                }
-
-                if (entry.isDirectory) {
-                    outFile.mkdirs()
-                } else {
-                    outFile.parentFile?.mkdirs()
-                    FileOutputStream(outFile).use { os ->
-                        while (true) {
-                            val n = zis.read(buf)
-                            if (n == -1) break
-                            os.write(buf, 0, n)
-                        }
-                    }
-                }
-                zis.closeEntry()
-                done++
-                onProgress((done * 100) / totalEntries)
-            }
-        }
-    }
-
-    private fun countZipEntries(zip: File): Int {
-        var count = 0
-        ZipInputStream(FileInputStream(zip)).use { zis -> while (zis.nextEntry != null) count++ }
-        return count
-    }
-
-    private fun deleteRecursively(f: File) {
-        if (!f.exists()) return
-        if (f.isDirectory) f.listFiles()?.forEach { deleteRecursively(it) }
-        f.delete()
     }
 }
 

--- a/app/src/main/java/com/shipthis/go/util/BuildLauncher.kt
+++ b/app/src/main/java/com/shipthis/go/util/BuildLauncher.kt
@@ -1,0 +1,220 @@
+package com.shipthis.go.util
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.google.android.play.core.splitinstall.SplitInstallManagerFactory
+import com.google.android.play.core.splitinstall.SplitInstallRequest
+import com.google.android.play.core.splitinstall.SplitInstallSessionState
+import com.google.android.play.core.splitinstall.SplitInstallStateUpdatedListener
+import com.google.android.play.core.splitinstall.model.SplitInstallSessionStatus
+import com.shipthis.go.data.model.GoBuild
+import java.io.*
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BuildLauncher @Inject constructor(
+    private val socketLogHandler: SocketLogHandler
+) {
+    
+    /**
+     * Launches a GoBuild by downloading, extracting, and starting the game.
+     * 
+     * @param context The application context
+     * @param goBuild The GoBuild to launch
+     * @param onProgress Optional callback for progress updates (used by HomeViewModel)
+     */
+    suspend fun launchBuild(
+        context: Context,
+        goBuild: GoBuild,
+        onProgress: ((String) -> Unit)? = null
+    ) {
+        val assetsDir = File(context.filesDir, "assets")
+        val zipFile = File(context.cacheDir, "game.zip")
+
+        onProgress?.invoke("Cleaning old files…")
+        deleteRecursively(assetsDir)
+        assetsDir.mkdirs()
+
+        onProgress?.invoke("Downloading game…")
+        downloadFile(goBuild.url, zipFile) { p ->
+            onProgress?.invoke("Downloading… $p%")
+        }
+
+        onProgress?.invoke("Unzipping game…")
+        unzip(zipFile, assetsDir) { p ->
+            onProgress?.invoke("Unzipping… $p%")
+        }
+
+        onProgress?.invoke("Launching…")
+
+        // Set buildId in log handler for runtime logging
+        socketLogHandler.setBuildId(goBuild.id)
+
+        // Mark the start of this runtime session
+        CrashMarker.markStart(context, goBuild.id)
+
+        val gameEngineVersion = goBuild.jobDetails.gameEngineVersion
+        launchGame(context, gameEngineVersion)
+    }
+
+    private fun launchGame(context: Context, version: String) {
+        val manager = SplitInstallManagerFactory.create(context)
+        val moduleName =
+            when (version) {
+                "4.5" -> "godot_v4_5"
+                "4.4" -> "godot_v4_4"
+                "4.3" -> "godot_v4_3"
+                "4.2" -> "godot_v4_2"
+                "4.1" -> "godot_v4_1"
+                "4.0" -> "godot_v4_0"
+                "3.6", "3.7" -> "godot_v3_x"
+                else -> "godot_v4_5"
+            }
+
+        if (manager.installedModules.contains(moduleName)) {
+            startGodotActivity(context, version)
+            return
+        }
+
+        val request = SplitInstallRequest.newBuilder().addModule(moduleName).build()
+
+        val listener = object : SplitInstallStateUpdatedListener {
+            override fun onStateUpdate(state: SplitInstallSessionState) {
+                if (state.moduleNames().contains(moduleName)) {
+                    when (state.status()) {
+                        SplitInstallSessionStatus.DOWNLOADING -> {
+                            Log.i(
+                                "ShipThis",
+                                "Downloading $moduleName (${state.bytesDownloaded()}/${state.totalBytesToDownload()})"
+                            )
+                        }
+                        SplitInstallSessionStatus.INSTALLING -> {
+                            Log.i("ShipThis", "Installing $moduleName…")
+                        }
+                        SplitInstallSessionStatus.INSTALLED -> {
+                            Log.i("ShipThis", "$moduleName installed, launching")
+                            manager.unregisterListener(this)
+                            startGodotActivity(context, version)
+                        }
+                        SplitInstallSessionStatus.FAILED -> {
+                            Log.e("ShipThis", "Install failed: ${state.errorCode()}")
+                            manager.unregisterListener(this)
+                        }
+                    }
+                }
+            }
+        }
+
+        manager.registerListener(listener)
+        manager.startInstall(request)
+    }
+
+    private fun startGodotActivity(context: Context, version: String) {
+        val className =
+            when (version) {
+                "4.5" -> "com.shipthis.go.GodotAppv4_5"
+                "4.4" -> "com.shipthis.go.GodotAppv4_4"
+                "4.3" -> "com.shipthis.go.GodotAppv4_3"
+                "4.2" -> "com.shipthis.go.GodotAppv4_2"
+                "4.1" -> "com.shipthis.go.GodotAppv4_1"
+                "4.0" -> "com.shipthis.go.GodotAppv4_0"
+                "3.6", "3.7" -> "com.shipthis.go.GodotAppv3_x"
+                else -> "com.shipthis.go.GodotAppv4_5"
+            }
+
+        val intent = Intent()
+        intent.setClassName(context.packageName, className)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+    }
+
+    // ---- IO helpers ----
+
+    private fun downloadFile(urlString: String, out: File, onProgress: (Int) -> Unit) {
+        val conn = URL(urlString).openConnection() as HttpURLConnection
+        conn.connectTimeout = 15000
+        conn.readTimeout = 300000
+        conn.connect()
+        val code = conn.responseCode
+        if (code != HttpURLConnection.HTTP_OK)
+            throw IOException("HTTP $code: ${conn.responseMessage}")
+
+        val length = conn.contentLength
+        var total = 0L
+        var lastPct = -1
+        conn.inputStream.buffered().use { input ->
+            FileOutputStream(out).buffered().use { output ->
+                val buf = ByteArray(8192)
+                while (true) {
+                    val n = input.read(buf)
+                    if (n == -1) break
+                    output.write(buf, 0, n)
+                    total += n
+                    if (length > 0) {
+                        val pct = (total * 100 / length).toInt()
+                        if (pct != lastPct) {
+                            lastPct = pct
+                            onProgress(pct)
+                        }
+                    }
+                }
+            }
+        }
+        conn.disconnect()
+    }
+
+    private fun unzip(zipFile: File, targetDir: File, onProgress: (Int) -> Unit) {
+        val totalEntries = countZipEntries(zipFile).coerceAtLeast(1)
+        var done = 0
+        ZipInputStream(FileInputStream(zipFile)).use { zis ->
+            var entry: ZipEntry?
+            val buf = ByteArray(8192)
+            while (true) {
+                entry = zis.nextEntry ?: break
+                val outFile = File(targetDir, entry.name)
+
+                // Zip Slip guard – prevents writing outside targetDir
+                val canonicalPath = outFile.canonicalPath
+                val canonicalTarget = targetDir.canonicalPath + File.separator
+                if (!canonicalPath.startsWith(canonicalTarget)) {
+                    throw IOException("Blocked Zip Slip: ${entry.name}")
+                }
+
+                if (entry.isDirectory) {
+                    outFile.mkdirs()
+                } else {
+                    outFile.parentFile?.mkdirs()
+                    FileOutputStream(outFile).use { os ->
+                        while (true) {
+                            val n = zis.read(buf)
+                            if (n == -1) break
+                            os.write(buf, 0, n)
+                        }
+                    }
+                }
+                zis.closeEntry()
+                done++
+                onProgress((done * 100) / totalEntries)
+            }
+        }
+    }
+
+    private fun countZipEntries(zip: File): Int {
+        var count = 0
+        ZipInputStream(FileInputStream(zip)).use { zis -> while (zis.nextEntry != null) count++ }
+        return count
+    }
+
+    private fun deleteRecursively(f: File) {
+        if (!f.exists()) return
+        if (f.isDirectory) f.listFiles()?.forEach { deleteRecursively(it) }
+        f.delete()
+    }
+}
+


### PR DESCRIPTION
## Overview

This is to resolve #9 - we added local persistence of the GoBuild model with the Room db storage and showing a list of previous launched builds.

## What's changed

- Used "Room" for local storage of builds
- Saving GoBuild to local storage on launch
- Added a "Builds" tab to the bottom navigation
- Removed TopAppBar from the logged in layout (was adding space at the top)

## Screenshot

<img width="921" height="2048" alt="image" src="https://github.com/user-attachments/assets/80a50a6c-fa47-462e-a01c-c2f4ec462ba0" />

